### PR TITLE
Upgrade deps (fix compile errors & tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /doc/
-/libs/
+/lib/
 /.crystal/
 /.shards/
 

--- a/benchmark.cr
+++ b/benchmark.cr
@@ -82,33 +82,31 @@ def print_table(result)
   get_empty_col_size = "get(empty)".size
   delete_col_size = result.values.map { |metrics| metrics["delete"].to_s.size }.max
 
-
   # header
   puts "| " + " " * store_col_size +
-      " | " + "set".ljust(set_col_size) +
-      " | " + "get".ljust(get_col_size) +
-      " | " + "get(empty)".ljust(get_empty_col_size) +
-      " | " + "delete".ljust(delete_col_size) +
-      " |"
+       " | " + "set".ljust(set_col_size) +
+       " | " + "get".ljust(get_col_size) +
+       " | " + "get(empty)".ljust(get_empty_col_size) +
+       " | " + "delete".ljust(delete_col_size) +
+       " |"
 
   puts "| " + "-" * store_col_size +
-      " | " + "-" * set_col_size +
-      " | " + "-" * get_col_size +
-      " | " + "-" * get_empty_col_size +
-      " | " + "-" * delete_col_size +
-      " |"
+       " | " + "-" * set_col_size +
+       " | " + "-" * get_col_size +
+       " | " + "-" * get_empty_col_size +
+       " | " + "-" * delete_col_size +
+       " |"
 
   # rows
   result.each do |store, metrics|
     puts "| " + store.ljust(store_col_size) +
-        " | " + metrics["set"].to_s.rjust(set_col_size) +
-        " | " + metrics["get"].to_s.rjust(get_col_size) +
-        " | " + metrics["get_empty"].to_s.rjust(get_empty_col_size) +
-        " | " + metrics["delete"].to_s.rjust(delete_col_size) +
-        " |"
+         " | " + metrics["set"].to_s.rjust(set_col_size) +
+         " | " + metrics["get"].to_s.rjust(get_col_size) +
+         " | " + metrics["get_empty"].to_s.rjust(get_empty_col_size) +
+         " | " + metrics["delete"].to_s.rjust(delete_col_size) +
+         " |"
   end
 end
-
 
 puts
 puts "Initializing stores..."

--- a/shard.yml
+++ b/shard.yml
@@ -12,7 +12,7 @@ development_dependencies:
     branch: master
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 1.6.5
+    version: ~> 1.8.0
   leveldb:
     github: crystal-community/leveldb
-    version: ~> 0.1.0
+    branch: master

--- a/src/kiwi/store.cr
+++ b/src/kiwi/store.cr
@@ -1,8 +1,8 @@
 module Kiwi
   abstract class Store
-    abstract def get(key : String) : String|Nil
+    abstract def get(key : String) : String | Nil
     abstract def set(key : String, val : String) : String
-    abstract def delete(key : String) : String|Nil
+    abstract def delete(key : String) : String | Nil
     abstract def clear : Store
 
     def []=(*args)


### PR DESCRIPTION
Leveldb 0.1.0 doesn't compile with crystal 0.23.1.

Source code formatted with `crystal tool format`.