### PR TITLE
fixes various incompatabilities with current versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ test:
 	$(CRYSTAL_BIN) spec
 
 benchmark:
-	$$(mkdir tmp -p)
+	$$(mkdir -p tmp)
 	$(CRYSTAL_BIN) build --release -o tmp/benchmark ./benchmark.cr $(CRFLAGS)
 	tmp/benchmark

--- a/src/kiwi/file_store.cr
+++ b/src/kiwi/file_store.cr
@@ -9,12 +9,12 @@ module Kiwi
       create_dir
     end
 
-    def get(key)
+    def get(key) : String | Nil
       file = file_for_key(key)
       File.exists?(file) ? File.read(file) : nil
     end
 
-    def set(key, val)
+    def set(key, val) : String
       create_dir unless dir_created?
 
       file = file_for_key(key)
@@ -22,7 +22,7 @@ module Kiwi
       val
     end
 
-    def delete(key)
+    def delete(key) : String
       create_dir unless dir_created?
 
       file = file_for_key(key)
@@ -31,11 +31,11 @@ module Kiwi
         File.delete(file)
         value
       else
-        nil
+        ""
       end
     end
 
-    def clear
+    def clear : Store
       remove_dir
       self
     end

--- a/src/kiwi/leveldb_store.cr
+++ b/src/kiwi/leveldb_store.cr
@@ -6,22 +6,22 @@ module Kiwi
     def initialize(@leveldb : ::LevelDB::DB)
     end
 
-    def set(key, val)
+    def set(key, val) : String
       @leveldb.put(key, val)
       val
     end
 
-    def get(key)
+    def get(key) : String | Nil
       @leveldb.get(key)
     end
 
-    def delete(key)
+    def delete(key) : String
       val = get(key)
       @leveldb.delete(key)
-      val
+      val || ""
     end
 
-    def clear
+    def clear : Store
       @leveldb.clear
       self
     end

--- a/src/kiwi/memcached_store.cr
+++ b/src/kiwi/memcached_store.cr
@@ -6,22 +6,22 @@ module Kiwi
     def initialize(@memcached : Memcached::Client)
     end
 
-    def set(key, val)
+    def set(key, val) : String
       @memcached.set(key, val)
       val
     end
 
-    def get(key)
+    def get(key) : String | Nil
       @memcached.get(key)
     end
 
-    def delete(key)
+    def delete(key) : String
       val = get(key)
       @memcached.delete(key)
-      val
+      val || ""
     end
 
-    def clear
+    def clear : Store
       @memcached.flush
       self
     end

--- a/src/kiwi/memory_store.cr
+++ b/src/kiwi/memory_store.cr
@@ -6,19 +6,19 @@ module Kiwi
       @mem = Hash(String, String).new
     end
 
-    def get(key)
+    def get(key) : String | Nil
       @mem[key]?
     end
 
-    def set(key, val)
+    def set(key, val) : String
       @mem[key] = val
     end
 
-    def delete(key)
-      @mem.delete(key)
+    def delete(key) : String
+      @mem.delete(key) || ""
     end
 
-    def clear
+    def clear : Store
       @mem.clear
       self
     end

--- a/src/kiwi/redis_store.cr
+++ b/src/kiwi/redis_store.cr
@@ -6,22 +6,22 @@ module Kiwi
     def initialize(@redis : Redis)
     end
 
-    def set(key, val)
+    def set(key, val) : String
       @redis.set(key, val)
       val
     end
 
-    def get(key)
+    def get(key) : String | Nil
       @redis.get(key)
     end
 
-    def delete(key)
+    def delete(key) : String
       val = get(key)
       @redis.del(key)
-      val
+      val || ""
     end
 
-    def clear
+    def clear : Store
       @redis.flushdb
       self
     end


### PR DESCRIPTION
This now works for me, with crystal 1.2.2 on macOS Monterey (ARM64), if anyone cares.

I'm not entirely sure if what it's measuring is the so-called "reality". Specifically, the in-memory store is three orders of mag faster for me than redis (1450x, see below).  There may be some compiler optimizations going on that completely bypass the work for that implementation. 

```
|                  | set      | get      | get(empty) | delete   |
| ---------------- | -------- | -------- | ---------- | -------- |
| **MemoryStore**  | 16871250 | 30060000 |   29883750 | 20672500 |
| **LevelDBStore** |    12500 |   441250 |     437500 |    50000 |
| **RedisStore**   |    11250 |    11250 |      11250 |     6250 |
| **FileStore**    |     4000 |    18750 |      18750 |    87500 |
```